### PR TITLE
Update docker-compose image

### DIFF
--- a/fluss-iceberg/docker-compose.yml
+++ b/fluss-iceberg/docker-compose.yml
@@ -65,7 +65,7 @@ services:
   #end
   #begin Flink cluster
   jobmanager:
-    image: apache/fluss-quickstart-flink:1.20-0.8.0-incubating
+    image: fluss/quickstart-flink-iceberg:1.20-0.8.0
     container_name: jobmanager
     ports:
       - "8083:8081"
@@ -80,7 +80,7 @@ services:
         FLINK_PROPERTIES=
         jobmanager.rpc.address: jobmanager
   taskmanager:
-    image: apache/fluss-quickstart-flink:1.20-0.8.0-incubating
+    image: fluss/quickstart-flink-iceberg:1.20-0.8.0
     container_name: taskmanager
     depends_on:
       - jobmanager
@@ -100,7 +100,7 @@ services:
   #end
   # Flink Lake Tiering Service
   flink-tiering:
-    image: apache/fluss-quickstart-flink:1.20-0.8.0-incubating
+    image: fluss/quickstart-flink-iceberg:1.20-0.8.0
     depends_on:
       - jobmanager
       - coordinator-server

--- a/fluss-iceberg/docker-compose.yml
+++ b/fluss-iceberg/docker-compose.yml
@@ -1,4 +1,3 @@
-
 x-common-environment: &common-environment
   AWS_ACCESS_KEY_ID: admin
   AWS_SECRET_ACCESS_KEY: password
@@ -7,10 +6,16 @@ x-common-environment: &common-environment
 services:
   #begin Fluss cluster
   coordinator-server:
-    image: fluss/fluss:0.8.0
+    image: apache/fluss:0.8.0-incubating
+    container_name: coordinator-server
     volumes:
       - ./lib:/tmp/lib
-    entrypoint: ["sh", "-c", "cp -v /tmp/lib/*.jar /opt/fluss/plugins/iceberg/ && exec /docker-entrypoint.sh coordinatorServer"]
+    entrypoint:
+      [
+        "sh",
+        "-c",
+        "cp -v /tmp/lib/*.jar /opt/fluss/plugins/iceberg/ && exec /docker-entrypoint.sh coordinatorServer",
+      ]
     depends_on:
       - zookeeper
       - rest
@@ -30,7 +35,8 @@ services:
         datalake.iceberg.s3.endpoint: http://minio:9000
         datalake.iceberg.s3.path-style-access: true
   tablet-server:
-    image: fluss/fluss:0.8.0
+    image: apache/fluss:0.8.0-incubating
+    container_name: tablet-server
     command: tabletServer
     depends_on:
       - coordinator-server
@@ -59,7 +65,8 @@ services:
   #end
   #begin Flink cluster
   jobmanager:
-    image: fluss/quickstart-flink-iceberg:1.20-0.8.0
+    image: apache/fluss-quickstart-flink:1.20-0.8.0-incubating
+    container_name: jobmanager
     ports:
       - "8083:8081"
     command: jobmanager
@@ -73,7 +80,8 @@ services:
         FLINK_PROPERTIES=
         jobmanager.rpc.address: jobmanager
   taskmanager:
-    image: fluss/quickstart-flink-iceberg:1.20-0.8.0
+    image: apache/fluss-quickstart-flink:1.20-0.8.0-incubating
+    container_name: taskmanager
     depends_on:
       - jobmanager
     command: taskmanager
@@ -90,10 +98,9 @@ services:
         taskmanager.memory.process.size: 2048m
         taskmanager.memory.framework.off-heap.size: 256m
   #end
-
   # Flink Lake Tiering Service
   flink-tiering:
-    image: fluss/quickstart-flink-iceberg:1.20-0.8.0
+    image: apache/fluss-quickstart-flink:1.20-0.8.0-incubating
     depends_on:
       - jobmanager
       - coordinator-server


### PR DESCRIPTION
- update docker-compose to use the Apache incubating images (fluss:0.8.0-incubating, fluss-quickstart-flink:1.20-0.8.0-incubating)
- add container_name entries for the main services and tidy the entrypoint formatting